### PR TITLE
Show toolbar only to admin users

### DIFF
--- a/src/app/components/AdminToolbar.tsx
+++ b/src/app/components/AdminToolbar.tsx
@@ -1,0 +1,10 @@
+"use client";
+import { VercelToolbar } from "@vercel/toolbar/next";
+import { getRole, isAdmin } from "../utils/credentials";
+
+// Show the Vercel toolbar only for admin users
+export function AdminToolbar() {
+    const role = getRole();
+    const isUserAdmin = role && isAdmin(role);
+    return isUserAdmin ? <VercelToolbar /> : null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import Header from "./components/Header/Header";
 import { headers } from "next/headers";
 import { Roboto } from "next/font/google";
 import ReactQueryProvider from "./components/Providers/react-query-provider";
-import { VercelToolbar } from "@vercel/toolbar/next";
+import { AdminToolbar } from "./components/AdminToolbar";
 
 const hideHeaderRoutes: string[] = [];
 const roboto = Roboto({
@@ -33,7 +33,7 @@ export default async function RootLayout({
             <body>
                 {shouldShowHeader && <Header />}
                 <ReactQueryProvider>{children}</ReactQueryProvider>
-                {showToolBar && <VercelToolbar />}
+                {showToolBar && <AdminToolbar />}
             </body>
         </html>
     );


### PR DESCRIPTION
This PR wil show [Vercel toolbar]() only to admin users and if `SHOW_TOOLBAR` .env variable is set to `true`

**_Note: It still shows it to owner of website even if not logged in._**